### PR TITLE
add not null constraints (disabled by default)

### DIFF
--- a/mongo_connector/doc_managers/mapping_schema.py
+++ b/mongo_connector/doc_managers/mapping_schema.py
@@ -123,6 +123,9 @@ MAPPING_SCHEMA = {
                 },
                 "dest": {
                     "type": "string"
+                },
+                "nullable": {
+                    "type": "boolean"
                 }
             },
             "required": ["type"]
@@ -131,7 +134,10 @@ MAPPING_SCHEMA = {
             "properties": {
                 "type": {"enum": ["_ARRAY"]},
                 "dest": {"type": "string"},
-                "fk": {"type": "string"}
+                "fk": {"type": "string"},
+                "nullable": {
+                    "type": "boolean"
+                }
             },
             "required": ["type", "dest", "fk"]
         },
@@ -140,7 +146,10 @@ MAPPING_SCHEMA = {
                 "type": {"enum": ["_ARRAY_OF_SCALARS"]},
                 "dest": {"type": "string"},
                 "fk": {"type": "string"},
-                "valueField": {"type": "string"}
+                "valueField": {"type": "string"},
+                "nullable": {
+                    "type": "boolean"
+                }
             },
             "required": ["type", "dest", "fk", "valueField"]
         }

--- a/mongo_connector/doc_managers/postgresql_manager.py
+++ b/mongo_connector/doc_managers/postgresql_manager.py
@@ -97,11 +97,15 @@ class DocManager(DocManagerBase):
                         if 'dest' in column_mapping:
                             name = column_mapping['dest']
                             column_type = column_mapping['type']
+                            nullable = column_mapping.get('nullable', True)
 
                             constraints = ''
                             if name == pk_name:
                                 constraints = "CONSTRAINT {0}_PK PRIMARY KEY".format(collection.upper())
                                 pk_found = True
+
+                            if not nullable:
+                                constraints = '{} NOT NULL'.format(constraints)
 
                             if column_type != ARRAY_TYPE and column_type != ARRAY_OF_SCALARS_TYPE:
                                 columns.append(name + ' ' + column_type + ' ' + constraints)


### PR DESCRIPTION
Hello,

This features adds the possibility to define columns as ``NOT NULL``.

In the mapping, you just have to add to the not nullable fields ``"nullable": false``.

If it is not present, ``nullable`` will defaults to ``true`` so it won't change the actual behavior.